### PR TITLE
Adding rep set to the BIOM table

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,7 @@ install:
     'pandas>=0.18' 'scipy>0.13.0' 'numpy>=1.7' 'h5py>=2.3.1'
   - source activate qiita_env
   - pip install sphinx sphinx-bootstrap-theme coveralls ipython[all]==2.4.1
-  - pip install https://github.com/josenavas/QiiTa/archive/unmoi-job-completion.zip --process-dependency-links
-  # - pip install https://github.com/biocore/qiita/archive/master.zip --process-dependency-links
+  - pip install https://github.com/biocore/qiita/archive/master.zip --process-dependency-links
   - ipython profile create qiita-general --parallel
   - qiita-env start_cluster qiita-general
   - qiita-env make --no-load-ontologies
@@ -28,14 +27,15 @@ install:
   - source activate env_name
   - pip install https://github.com/qiita-spots/qiita_client/archive/master.zip
   - travis_retry pip install . --process-dependency-links
+  - configure_biom --env-script "source activate env_name" --server-cert $QIITA_SERVER_CERT
 before_script:
   - source activate qiita_env
   - export MOI_CONFIG_FP=$HOME/miniconda3/envs/qiita_env/lib/python2.7/site-packages/qiita_core/support_files/config_test.cfg
+  - qiita plugins update
   - qiita pet webserver --no-build-docs start &
 script:
   - source activate env_name
   - sleep 5 # give enough time to the webserver to start
-  - configure_biom --env-script "source activate env_name" --server-cert $QIITA_SERVER_CERT
   - nosetests --with-doctest --with-coverage -v
   - flake8 qtp_biom setup.py scripts
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,7 @@ before_script:
 script:
   - source activate env_name
   - sleep 5 # give enough time to the webserver to start
+  - python qtp_biom/tests/test_plugin.py
   - nosetests --with-coverage -v
   - flake8 qtp_biom setup.py scripts
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ install:
   - travis_retry conda create --yes -n env_name python=$PYTHON_VERSION pip nose flake8 coverage numpy pandas 'h5py>=2.3.1' matplotlib seaborn
   - source activate env_name
   - pip install https://github.com/qiita-spots/qiita_client/archive/master.zip
-  - travis_retry pip install .
+  - travis_retry pip install . --process-dependency-links
 before_script:
   - source activate qiita_env
   - export MOI_CONFIG_FP=$HOME/miniconda3/envs/qiita_env/lib/python2.7/site-packages/qiita_core/support_files/config_test.cfg

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,8 @@ install:
     'pandas>=0.18' 'scipy>0.13.0' 'numpy>=1.7' 'h5py>=2.3.1'
   - source activate qiita_env
   - pip install sphinx sphinx-bootstrap-theme coveralls ipython[all]==2.4.1
-  - pip install https://github.com/biocore/qiita/archive/master.zip --process-dependency-links
+  - pip install https://github.com/josenavas/QiiTa/archive/unmoi-job-completion.zip --process-dependency-links
+  # - pip install https://github.com/biocore/qiita/archive/master.zip --process-dependency-links
   - ipython profile create qiita-general --parallel
   - qiita-env start_cluster qiita-general
   - qiita-env make --no-load-ontologies

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ script:
   - source activate env_name
   - sleep 5 # give enough time to the webserver to start
   - configure_biom --env-script "source activate env_name" --server-cert $QIITA_SERVER_CERT
-  - nosetests --with-doctest --with-coverage -v
+  - nosetests --with-coverage -v
   - flake8 qtp_biom setup.py scripts
 addons:
   postgresql: "9.3"

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ script:
   - source activate env_name
   - sleep 5 # give enough time to the webserver to start
   - configure_biom --env-script "source activate env_name" --server-cert $QIITA_SERVER_CERT
-  - nosetests --with-doctest --with-coverage
+  - nosetests --with-doctest --with-coverage -v
   - flake8 qtp_biom setup.py scripts
 addons:
   postgresql: "9.3"

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,17 +27,15 @@ install:
   - source activate env_name
   - pip install https://github.com/qiita-spots/qiita_client/archive/master.zip
   - travis_retry pip install . --process-dependency-links
-  - configure_biom --env-script "source activate env_name" --server-cert $QIITA_SERVER_CERT
 before_script:
   - source activate qiita_env
   - export MOI_CONFIG_FP=$HOME/miniconda3/envs/qiita_env/lib/python2.7/site-packages/qiita_core/support_files/config_test.cfg
-  - qiita plugins update
   - qiita pet webserver --no-build-docs start &
 script:
   - source activate env_name
   - sleep 5 # give enough time to the webserver to start
-  - python qtp_biom/tests/test_plugin.py
-  - nosetests --with-coverage -v
+  - configure_biom --env-script "source activate env_name" --server-cert $QIITA_SERVER_CERT
+  - nosetests --with-doctest --with-coverage -v
   - flake8 qtp_biom setup.py scripts
 addons:
   postgresql: "9.3"

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,14 +27,15 @@ install:
   - source activate env_name
   - pip install https://github.com/qiita-spots/qiita_client/archive/master.zip
   - travis_retry pip install . --process-dependency-links
+  - configure_biom --env-script "source activate env_name" --server-cert $QIITA_SERVER_CERT
 before_script:
   - source activate qiita_env
   - export MOI_CONFIG_FP=$HOME/miniconda3/envs/qiita_env/lib/python2.7/site-packages/qiita_core/support_files/config_test.cfg
+  - qiita plugins update
   - qiita pet webserver --no-build-docs start &
 script:
   - source activate env_name
   - sleep 5 # give enough time to the webserver to start
-  - configure_biom --env-script "source activate env_name" --server-cert $QIITA_SERVER_CERT
   - nosetests --with-coverage -v
   - flake8 qtp_biom setup.py scripts
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ install:
 before_script:
   - source activate qiita_env
   - export MOI_CONFIG_FP=$HOME/miniconda3/envs/qiita_env/lib/python2.7/site-packages/qiita_core/support_files/config_test.cfg
-  - qiita pet webserver start &
+  - qiita pet webserver --no-build-docs start &
 script:
   - source activate env_name
   - sleep 5 # give enough time to the webserver to start

--- a/qtp_biom/__init__.py
+++ b/qtp_biom/__init__.py
@@ -14,7 +14,8 @@ from .summary import generate_html_summary
 # Define the supported artifact types
 artifact_types = [
     QiitaArtifactType('BIOM', 'BIOM table', False, False,
-                      [('biom', True), ('directory', False), ('log', False)])]
+                      [('biom', True), ('directory', False), ('log', False),
+                       ('preprocessed_fasta', False)])]
 
 # Initialize the plugin
 plugin = QiitaTypePlugin('BIOM type', '2.1.4',

--- a/qtp_biom/tests/test_plugin.py
+++ b/qtp_biom/tests/test_plugin.py
@@ -35,14 +35,14 @@ class PluginTests(PluginTestCase):
                 else:
                     remove(fp)
 
-    # def _wait_job(self, job_id):
-    #     for i in range(5):
-    #         status = self.qclient.get_job_info(job_id)['status']
-    #         if status != 'running':
-    #             break
-    #         sleep(0.5)
-    #     return status
-    #
+    def _wait_job(self, job_id):
+        for i in range(5):
+            status = self.qclient.get_job_info(job_id)['status']
+            if status != 'running':
+                break
+            sleep(0.5)
+        return status
+
     def test_execute_job_summary(self):
         # Create a summary job
         data = {'command': dumps(['BIOM type', '2.1.4',
@@ -56,66 +56,66 @@ class PluginTests(PluginTestCase):
 
         obs = self._wait_job(job_id)
         self.assertEqual(obs, 'success')
-    #
-    # def test_execute_job_validate(self):
-    #     # Create a prep template
-    #     prep_info = {'SKB8.640193': {'col': 'val1'},
-    #                  'SKD8.640184': {'col': 'val2'}}
-    #     data = {'prep_info': dumps(prep_info),
-    #             'study': 1,
-    #             'data_type': '16S'}
-    #     template = self.qclient.post(
-    #         '/apitest/prep_template/', data=data)['prep']
-    #     # Create a new validate job
-    #     fd, biom_fp = mkstemp(suffix=".biom")
-    #     close(fd)
-    #     data = np.random.randint(100, size=(2, 2))
-    #     table = Table(data, ['O1', 'O2'], ['SKB8.640193', 'SKD8.640184'])
-    #     with biom_open(biom_fp, 'w') as f:
-    #         table.to_hdf5(f, "Test")
-    #     data = {'command': dumps(['BIOM type', '2.1.4', 'Validate']),
-    #             'parameters': dumps(
-    #                 {'files': dumps({'biom': [biom_fp]}),
-    #                  'template': template,
-    #                  'artifact_type': 'BIOM'}),
-    #             'artifact_type': 'BIOM',
-    #             'status': 'queued'}
-    #     job_id = self.qclient.post(
-    #         '/apitest/processing_job/', data=data)['job']
-    #
-    #     plugin("https://localhost:21174", job_id, self.out_dir)
-    #     obs = self._wait_job(job_id)
-    #     self.assertEqual(obs, 'success')
-    #
-    # def test_execute_job_error(self):
-    #     # Create a prep template
-    #     prep_info = {'SKB8.640193': {'col': 'val1'},
-    #                  'SKD8.640184': {'col': 'val2'}}
-    #     data = {'prep_info': dumps(prep_info),
-    #             'study': 1,
-    #             'data_type': '16S'}
-    #     template = self.qclient.post(
-    #         '/apitest/prep_template/', data=data)['prep']
-    #     # Create a new validate job
-    #     fd, biom_fp = mkstemp(suffix=".biom")
-    #     close(fd)
-    #     data = np.random.randint(100, size=(2, 2))
-    #     table = Table(data, ['O1', 'O2'], ['S1', 'S2'])
-    #     with biom_open(biom_fp, 'w') as f:
-    #         table.to_hdf5(f, "Test")
-    #     data = {'command': dumps(['BIOM type', '2.1.4', 'Validate']),
-    #             'parameters': dumps(
-    #                 {'files': dumps({'biom': [biom_fp]}),
-    #                  'template': template,
-    #                  'artifact_type': 'BIOM'}),
-    #             'artifact_type': 'BIOM',
-    #             'status': 'queued'}
-    #     job_id = self.qclient.post(
-    #         '/apitest/processing_job/', data=data)['job']
-    #
-    #     plugin("https://localhost:21174", job_id, self.out_dir)
-    #     obs = self._wait_job(job_id)
-    #     self.assertEqual(obs, 'error')
+
+    def test_execute_job_validate(self):
+        # Create a prep template
+        prep_info = {'SKB8.640193': {'col': 'val1'},
+                     'SKD8.640184': {'col': 'val2'}}
+        data = {'prep_info': dumps(prep_info),
+                'study': 1,
+                'data_type': '16S'}
+        template = self.qclient.post(
+            '/apitest/prep_template/', data=data)['prep']
+        # Create a new validate job
+        fd, biom_fp = mkstemp(suffix=".biom")
+        close(fd)
+        data = np.random.randint(100, size=(2, 2))
+        table = Table(data, ['O1', 'O2'], ['SKB8.640193', 'SKD8.640184'])
+        with biom_open(biom_fp, 'w') as f:
+            table.to_hdf5(f, "Test")
+        data = {'command': dumps(['BIOM type', '2.1.4', 'Validate']),
+                'parameters': dumps(
+                    {'files': dumps({'biom': [biom_fp]}),
+                     'template': template,
+                     'artifact_type': 'BIOM'}),
+                'artifact_type': 'BIOM',
+                'status': 'queued'}
+        job_id = self.qclient.post(
+            '/apitest/processing_job/', data=data)['job']
+
+        plugin("https://localhost:21174", job_id, self.out_dir)
+        obs = self._wait_job(job_id)
+        self.assertEqual(obs, 'success')
+
+    def test_execute_job_error(self):
+        # Create a prep template
+        prep_info = {'SKB8.640193': {'col': 'val1'},
+                     'SKD8.640184': {'col': 'val2'}}
+        data = {'prep_info': dumps(prep_info),
+                'study': 1,
+                'data_type': '16S'}
+        template = self.qclient.post(
+            '/apitest/prep_template/', data=data)['prep']
+        # Create a new validate job
+        fd, biom_fp = mkstemp(suffix=".biom")
+        close(fd)
+        data = np.random.randint(100, size=(2, 2))
+        table = Table(data, ['O1', 'O2'], ['S1', 'S2'])
+        with biom_open(biom_fp, 'w') as f:
+            table.to_hdf5(f, "Test")
+        data = {'command': dumps(['BIOM type', '2.1.4', 'Validate']),
+                'parameters': dumps(
+                    {'files': dumps({'biom': [biom_fp]}),
+                     'template': template,
+                     'artifact_type': 'BIOM'}),
+                'artifact_type': 'BIOM',
+                'status': 'queued'}
+        job_id = self.qclient.post(
+            '/apitest/processing_job/', data=data)['job']
+
+        plugin("https://localhost:21174", job_id, self.out_dir)
+        obs = self._wait_job(job_id)
+        self.assertEqual(obs, 'error')
 
 if __name__ == '__main__':
     main()

--- a/qtp_biom/tests/test_plugin.py
+++ b/qtp_biom/tests/test_plugin.py
@@ -40,7 +40,8 @@ class PluginTests(PluginTestCase):
             status = self.qclient.get_job_info(job_id)['status']
             if status != 'running':
                 break
-            sleep(1)
+            sleep(0.5)
+            print "TRYING TO DEBUG IN HERE"
         return status
 
     def test_execute_job_summary(self):
@@ -113,8 +114,11 @@ class PluginTests(PluginTestCase):
         job_id = self.qclient.post(
             '/apitest/processing_job/', data=data)['job']
 
+        print "WHAT ABOUT HERE?"
         plugin("https://localhost:21174", job_id, self.out_dir)
+        print "HEY DONE!!!"
         obs = self._wait_job(job_id)
+        print "I CAN'T WAIT ANYMORE"
         self.assertEqual(obs, 'error')
 
 if __name__ == '__main__':

--- a/qtp_biom/tests/test_plugin.py
+++ b/qtp_biom/tests/test_plugin.py
@@ -90,6 +90,7 @@ class PluginTests(PluginTestCase):
 
     def test_execute_job_error(self):
         # Create a prep template
+        print "START TEST"
         prep_info = {'SKB8.640193': {'col': 'val1'},
                      'SKD8.640184': {'col': 'val2'}}
         data = {'prep_info': dumps(prep_info),
@@ -97,6 +98,7 @@ class PluginTests(PluginTestCase):
                 'data_type': '16S'}
         template = self.qclient.post(
             '/apitest/prep_template/', data=data)['prep']
+        print "PREP TEMPLATE CREATED"
         # Create a new validate job
         fd, biom_fp = mkstemp(suffix=".biom")
         close(fd)
@@ -104,6 +106,7 @@ class PluginTests(PluginTestCase):
         table = Table(data, ['O1', 'O2'], ['S1', 'S2'])
         with biom_open(biom_fp, 'w') as f:
             table.to_hdf5(f, "Test")
+        print "BIOM TABLE CREATED"
         data = {'command': dumps(['BIOM type', '2.1.4', 'Validate']),
                 'parameters': dumps(
                     {'files': dumps({'biom': [biom_fp]}),
@@ -113,6 +116,7 @@ class PluginTests(PluginTestCase):
                 'status': 'queued'}
         job_id = self.qclient.post(
             '/apitest/processing_job/', data=data)['job']
+        print "JOB CREATED"
 
         print "WHAT ABOUT HERE?"
         plugin("https://localhost:21174", job_id, self.out_dir)

--- a/qtp_biom/tests/test_plugin.py
+++ b/qtp_biom/tests/test_plugin.py
@@ -35,15 +35,14 @@ class PluginTests(PluginTestCase):
                 else:
                     remove(fp)
 
-    def _wait_job(self, job_id):
-        for i in range(5):
-            status = self.qclient.get_job_info(job_id)['status']
-            if status != 'running':
-                break
-            sleep(0.5)
-            print "TRYING TO DEBUG IN HERE"
-        return status
-
+    # def _wait_job(self, job_id):
+    #     for i in range(5):
+    #         status = self.qclient.get_job_info(job_id)['status']
+    #         if status != 'running':
+    #             break
+    #         sleep(0.5)
+    #     return status
+    #
     def test_execute_job_summary(self):
         # Create a summary job
         data = {'command': dumps(['BIOM type', '2.1.4',
@@ -57,73 +56,66 @@ class PluginTests(PluginTestCase):
 
         obs = self._wait_job(job_id)
         self.assertEqual(obs, 'success')
-
-    def test_execute_job_validate(self):
-        # Create a prep template
-        prep_info = {'SKB8.640193': {'col': 'val1'},
-                     'SKD8.640184': {'col': 'val2'}}
-        data = {'prep_info': dumps(prep_info),
-                'study': 1,
-                'data_type': '16S'}
-        template = self.qclient.post(
-            '/apitest/prep_template/', data=data)['prep']
-        # Create a new validate job
-        fd, biom_fp = mkstemp(suffix=".biom")
-        close(fd)
-        data = np.random.randint(100, size=(2, 2))
-        table = Table(data, ['O1', 'O2'], ['SKB8.640193', 'SKD8.640184'])
-        with biom_open(biom_fp, 'w') as f:
-            table.to_hdf5(f, "Test")
-        data = {'command': dumps(['BIOM type', '2.1.4', 'Validate']),
-                'parameters': dumps(
-                    {'files': dumps({'biom': [biom_fp]}),
-                     'template': template,
-                     'artifact_type': 'BIOM'}),
-                'artifact_type': 'BIOM',
-                'status': 'queued'}
-        job_id = self.qclient.post(
-            '/apitest/processing_job/', data=data)['job']
-
-        plugin("https://localhost:21174", job_id, self.out_dir)
-        obs = self._wait_job(job_id)
-        self.assertEqual(obs, 'success')
-
-    def test_execute_job_error(self):
-        # Create a prep template
-        print "START TEST"
-        prep_info = {'SKB8.640193': {'col': 'val1'},
-                     'SKD8.640184': {'col': 'val2'}}
-        data = {'prep_info': dumps(prep_info),
-                'study': 1,
-                'data_type': '16S'}
-        template = self.qclient.post(
-            '/apitest/prep_template/', data=data)['prep']
-        print "PREP TEMPLATE CREATED"
-        # Create a new validate job
-        fd, biom_fp = mkstemp(suffix=".biom")
-        close(fd)
-        data = np.random.randint(100, size=(2, 2))
-        table = Table(data, ['O1', 'O2'], ['S1', 'S2'])
-        with biom_open(biom_fp, 'w') as f:
-            table.to_hdf5(f, "Test")
-        print "BIOM TABLE CREATED"
-        data = {'command': dumps(['BIOM type', '2.1.4', 'Validate']),
-                'parameters': dumps(
-                    {'files': dumps({'biom': [biom_fp]}),
-                     'template': template,
-                     'artifact_type': 'BIOM'}),
-                'artifact_type': 'BIOM',
-                'status': 'queued'}
-        job_id = self.qclient.post(
-            '/apitest/processing_job/', data=data)['job']
-        print "JOB CREATED"
-
-        print "WHAT ABOUT HERE?"
-        plugin("https://localhost:21174", job_id, self.out_dir)
-        print "HEY DONE!!!"
-        obs = self._wait_job(job_id)
-        print "I CAN'T WAIT ANYMORE"
-        self.assertEqual(obs, 'error')
+    #
+    # def test_execute_job_validate(self):
+    #     # Create a prep template
+    #     prep_info = {'SKB8.640193': {'col': 'val1'},
+    #                  'SKD8.640184': {'col': 'val2'}}
+    #     data = {'prep_info': dumps(prep_info),
+    #             'study': 1,
+    #             'data_type': '16S'}
+    #     template = self.qclient.post(
+    #         '/apitest/prep_template/', data=data)['prep']
+    #     # Create a new validate job
+    #     fd, biom_fp = mkstemp(suffix=".biom")
+    #     close(fd)
+    #     data = np.random.randint(100, size=(2, 2))
+    #     table = Table(data, ['O1', 'O2'], ['SKB8.640193', 'SKD8.640184'])
+    #     with biom_open(biom_fp, 'w') as f:
+    #         table.to_hdf5(f, "Test")
+    #     data = {'command': dumps(['BIOM type', '2.1.4', 'Validate']),
+    #             'parameters': dumps(
+    #                 {'files': dumps({'biom': [biom_fp]}),
+    #                  'template': template,
+    #                  'artifact_type': 'BIOM'}),
+    #             'artifact_type': 'BIOM',
+    #             'status': 'queued'}
+    #     job_id = self.qclient.post(
+    #         '/apitest/processing_job/', data=data)['job']
+    #
+    #     plugin("https://localhost:21174", job_id, self.out_dir)
+    #     obs = self._wait_job(job_id)
+    #     self.assertEqual(obs, 'success')
+    #
+    # def test_execute_job_error(self):
+    #     # Create a prep template
+    #     prep_info = {'SKB8.640193': {'col': 'val1'},
+    #                  'SKD8.640184': {'col': 'val2'}}
+    #     data = {'prep_info': dumps(prep_info),
+    #             'study': 1,
+    #             'data_type': '16S'}
+    #     template = self.qclient.post(
+    #         '/apitest/prep_template/', data=data)['prep']
+    #     # Create a new validate job
+    #     fd, biom_fp = mkstemp(suffix=".biom")
+    #     close(fd)
+    #     data = np.random.randint(100, size=(2, 2))
+    #     table = Table(data, ['O1', 'O2'], ['S1', 'S2'])
+    #     with biom_open(biom_fp, 'w') as f:
+    #         table.to_hdf5(f, "Test")
+    #     data = {'command': dumps(['BIOM type', '2.1.4', 'Validate']),
+    #             'parameters': dumps(
+    #                 {'files': dumps({'biom': [biom_fp]}),
+    #                  'template': template,
+    #                  'artifact_type': 'BIOM'}),
+    #             'artifact_type': 'BIOM',
+    #             'status': 'queued'}
+    #     job_id = self.qclient.post(
+    #         '/apitest/processing_job/', data=data)['job']
+    #
+    #     plugin("https://localhost:21174", job_id, self.out_dir)
+    #     obs = self._wait_job(job_id)
+    #     self.assertEqual(obs, 'error')
 
 if __name__ == '__main__':
     main()

--- a/qtp_biom/tests/test_plugin.py
+++ b/qtp_biom/tests/test_plugin.py
@@ -113,9 +113,7 @@ class PluginTests(PluginTestCase):
         job_id = self.qclient.post(
             '/apitest/processing_job/', data=data)['job']
 
-        print "Call to plugin from the test!"
         plugin("https://localhost:21174", job_id, self.out_dir)
-        print "Done calling plugin!"
         obs = self._wait_job(job_id)
         self.assertEqual(obs, 'error')
 

--- a/qtp_biom/tests/test_plugin.py
+++ b/qtp_biom/tests/test_plugin.py
@@ -36,7 +36,7 @@ class PluginTests(PluginTestCase):
                     remove(fp)
 
     def _wait_job(self, job_id):
-        for i in range(5):
+        for i in range(10):
             status = self.qclient.get_job_info(job_id)['status']
             if status != 'running':
                 break

--- a/qtp_biom/tests/test_plugin.py
+++ b/qtp_biom/tests/test_plugin.py
@@ -113,7 +113,9 @@ class PluginTests(PluginTestCase):
         job_id = self.qclient.post(
             '/apitest/processing_job/', data=data)['job']
 
+        print "Call to plugin from the test!"
         plugin("https://localhost:21174", job_id, self.out_dir)
+        print "Done calling plugin!"
         obs = self._wait_job(job_id)
         self.assertEqual(obs, 'error')
 

--- a/qtp_biom/validate.py
+++ b/qtp_biom/validate.py
@@ -46,17 +46,20 @@ def validate(qclient, job_id, parameters, out_dir):
         return (False, None, "Unknown artifact type %s. Supported types: BIOM"
                              % a_type)
 
+    print "Collecting prep information"
     qclient.update_job_step(job_id, "Step 1: Collecting prep information")
     prep_info = qclient.get("/qiita_db/prep_template/%s/data/" % prep_id)
     prep_info = prep_info['data']
 
     # Check if the biom table has the same sample ids as the prep info
+    print "Validating BIOM file"
     qclient.update_job_step(job_id, "Step 2: Validting BIOM file")
     new_biom_fp = biom_fp = files['biom'][0]
     table = load_table(biom_fp)
     pt_sample_ids = set(prep_info)
     biom_sample_ids = set(table.ids())
 
+    print "Some if in validate"
     if not pt_sample_ids.issuperset(biom_sample_ids):
         # The BIOM sample ids are different from the ones in the prep template
         qclient.update_job_step(job_id, "Step 3: Fixing BIOM sample ids")
@@ -96,6 +99,7 @@ def validate(qclient, job_id, parameters, out_dir):
 
     filepaths = [(new_biom_fp, 'biom')]
 
+    print "Is there a representative set?"
     # Validate the representative set, if it exists
     if 'preprocessed_fasta' in files:
         repset_fp = files['preprocessed_fasta'][0]
@@ -126,9 +130,11 @@ def validate(qclient, job_id, parameters, out_dir):
 
         filepaths.append((repset_fp, 'preprocessed_fasta'))
 
+    print "Getting the files in place"
     for fp_type, fps in files.items():
         if fp_type not in ('biom', 'preprocessed_fasta'):
             for fp in fps:
                 filepaths.append((fp, fp_type))
 
+    print "Done! Returning!"
     return True, [ArtifactInfo(None, 'BIOM', filepaths)], ""

--- a/qtp_biom/validate.py
+++ b/qtp_biom/validate.py
@@ -82,6 +82,7 @@ def validate(qclient, job_id, parameters, out_dir):
                              'provide the column "run_prefix" in the prep '
                              'information to map the existing sample ids to '
                              'the prep information sample ids.')
+                print "EXIT POINT 1"
                 return False, None, error_msg
 
         # Fix the sample ids
@@ -91,8 +92,10 @@ def validate(qclient, job_id, parameters, out_dir):
             missing = biom_sample_ids - set(id_map)
             error_msg = ('Your prep information is missing samples that are '
                          'present in your BIOM table: %s' % ', '.join(missing))
+            print "EXIT POINT 2"
             return False, None, error_msg
 
+        print "WRITING TABLE"
         new_biom_fp = join(out_dir, basename(biom_fp))
         with biom_open(new_biom_fp, 'w') as f:
             table.to_hdf5(f, "Qiita BIOM type plugin")

--- a/qtp_biom/validate.py
+++ b/qtp_biom/validate.py
@@ -46,20 +46,17 @@ def validate(qclient, job_id, parameters, out_dir):
         return (False, None, "Unknown artifact type %s. Supported types: BIOM"
                              % a_type)
 
-    print "Collecting prep information"
     qclient.update_job_step(job_id, "Step 1: Collecting prep information")
     prep_info = qclient.get("/qiita_db/prep_template/%s/data/" % prep_id)
     prep_info = prep_info['data']
 
     # Check if the biom table has the same sample ids as the prep info
-    print "Validating BIOM file"
     qclient.update_job_step(job_id, "Step 2: Validting BIOM file")
     new_biom_fp = biom_fp = files['biom'][0]
     table = load_table(biom_fp)
     pt_sample_ids = set(prep_info)
     biom_sample_ids = set(table.ids())
 
-    print "Some if in validate"
     if not pt_sample_ids.issuperset(biom_sample_ids):
         # The BIOM sample ids are different from the ones in the prep template
         qclient.update_job_step(job_id, "Step 3: Fixing BIOM sample ids")
@@ -82,7 +79,6 @@ def validate(qclient, job_id, parameters, out_dir):
                              'provide the column "run_prefix" in the prep '
                              'information to map the existing sample ids to '
                              'the prep information sample ids.')
-                print "EXIT POINT 1"
                 return False, None, error_msg
 
         # Fix the sample ids
@@ -92,17 +88,14 @@ def validate(qclient, job_id, parameters, out_dir):
             missing = biom_sample_ids - set(id_map)
             error_msg = ('Your prep information is missing samples that are '
                          'present in your BIOM table: %s' % ', '.join(missing))
-            print "EXIT POINT 2"
             return False, None, error_msg
 
-        print "WRITING TABLE"
         new_biom_fp = join(out_dir, basename(biom_fp))
         with biom_open(new_biom_fp, 'w') as f:
             table.to_hdf5(f, "Qiita BIOM type plugin")
 
     filepaths = [(new_biom_fp, 'biom')]
 
-    print "Is there a representative set?"
     # Validate the representative set, if it exists
     if 'preprocessed_fasta' in files:
         repset_fp = files['preprocessed_fasta'][0]
@@ -133,11 +126,9 @@ def validate(qclient, job_id, parameters, out_dir):
 
         filepaths.append((repset_fp, 'preprocessed_fasta'))
 
-    print "Getting the files in place"
     for fp_type, fps in files.items():
         if fp_type not in ('biom', 'preprocessed_fasta'):
             for fp in fps:
                 filepaths.append((fp, fp_type))
 
-    print "Done! Returning!"
     return True, [ArtifactInfo(None, 'BIOM', filepaths)], ""

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,9 @@ setup(name='qtp-biom',
       scripts=glob('scripts/*'),
       extras_require={'test': ["nose >= 0.10.1", "pep8"]},
       install_requires=['click >= 3.3', 'biom-format >= 2.1.4, < 2.2.0',
-                        'seaborn', 'qiita_client'],
+                        'seaborn', 'qiita_client', 'qiita-files'],
+      dependency_links=[
+        'https://github.com/qiita-spots/qiita-files/archive/master.zip#'
+        'egg=qiita-files-0.1.0-dev'],
       classifiers=classifiers
       )


### PR DESCRIPTION
This add the notion of a representative set to the BIOM table. The representative set doesn't make sense outside of the attached BIOM table. With both of this files, we can validate that the representative set and the biom contain the same observation ids.