### PR TITLE
Supporting rarefied tables

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,17 +12,17 @@ before_install:
   # Update conda itself
   - conda update --yes conda
 install:
-  - travis_retry conda create --yes -n qiita_env python=2.7 pip nose flake8
+  - travis_retry conda create --yes -n qiita python=2.7 pip nose flake8
     pyzmq networkx pyparsing natsort mock future libgfortran
     'pandas>=0.18' 'scipy>0.13.0' 'numpy>=1.7' 'h5py>=2.3.1'
-  - source activate qiita_env
+  - source activate qiita
   - pip install sphinx sphinx-bootstrap-theme coveralls ipython[all]==2.4.1
   - pip install https://github.com/biocore/qiita/archive/master.zip --process-dependency-links
-  - export MOI_CONFIG_FP=$HOME/miniconda3/envs/qiita_env/lib/python2.7/site-packages/qiita_core/support_files/config_test.cfg
+  - export MOI_CONFIG_FP=$HOME/miniconda3/envs/qiita/lib/python2.7/site-packages/qiita_core/support_files/config_test.cfg
   - ipython profile create qiita-general --parallel
   - qiita-env start_cluster qiita-general
   - qiita-env make --no-load-ontologies
-  - export QIITA_SERVER_CERT=$HOME/miniconda3/envs/qiita_env/lib/python2.7/site-packages/qiita_core/support_files/server.crt
+  - export QIITA_SERVER_CERT=$HOME/miniconda3/envs/qiita/lib/python2.7/site-packages/qiita_core/support_files/server.crt
   - source deactivate
   - travis_retry conda create --yes -n env_name python=$PYTHON_VERSION pip nose flake8 coverage numpy pandas 'h5py>=2.3.1' matplotlib seaborn
   - source activate env_name
@@ -30,7 +30,7 @@ install:
   - travis_retry pip install . --process-dependency-links
   - configure_biom --env-script "source activate env_name" --server-cert $QIITA_SERVER_CERT
 before_script:
-  - source activate qiita_env
+  - source activate qiita
   - qiita plugins update
   - qiita pet webserver --no-build-docs start &
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ install:
     'pandas>=0.18' 'scipy>0.13.0' 'numpy>=1.7' 'h5py>=2.3.1'
   - source activate qiita_env
   - pip install sphinx sphinx-bootstrap-theme coveralls ipython[all]==2.4.1
-  - pip install https://github.com/biocore/qiita/archive/analysis-refactor.zip --process-dependency-links
+  - pip install https://github.com/biocore/qiita/archive/master.zip --process-dependency-links
   - export MOI_CONFIG_FP=$HOME/miniconda3/envs/qiita_env/lib/python2.7/site-packages/qiita_core/support_files/config_test.cfg
   - ipython profile create qiita-general --parallel
   - qiita-env start_cluster qiita-general

--- a/qtp_biom/summary.py
+++ b/qtp_biom/summary.py
@@ -61,7 +61,8 @@ def _generate_html(biom):
     if sample_count_summary['Minimum count'] == sample_count_summary[
             'Maximum count']:
         artifact_information.append(
-            "All the samples in your BIOM table have %d sequences"
+            "All the samples in your BIOM table have %d sequences, "
+            "no plot will be shown below."
             % sample_count_summary['Minimum count'])
     else:
         ax = sns.distplot(sample_counts)

--- a/qtp_biom/tests/test_summary.py
+++ b/qtp_biom/tests/test_summary.py
@@ -13,9 +13,11 @@ from os.path import exists, isdir
 from shutil import rmtree
 from json import dumps
 
+from biom import Table
+import numpy as np
 from qiita_client.testing import PluginTestCase
 
-from qtp_biom.summary import generate_html_summary
+from qtp_biom.summary import generate_html_summary, _generate_html
 
 
 class SummaryTestsWith(PluginTestCase):
@@ -60,6 +62,13 @@ class SummaryTestsWith(PluginTestCase):
             html = html_f.read()
         self.assertRegexpMatches(html, '\n'.join(EXP_HTML_REGEXP))
 
+    def test_generate_html_summary_rarefied(self):
+        # Create a new biom table
+        data = np.asarray([[0, 2, 4], [2, 2, 2], [4, 2, 0]])
+        table = Table(data, ['O1', 'O2', 'O3'], ['S1', 'S2', 'S3'])
+        obs = _generate_html(table)
+        self.assertEqual(obs, '\n'.join(EXP_HTML_RAREFIED))
+
 
 EXP_HTML_REGEXP = [
     '<b>Number of samples:</b> 7<br/>',
@@ -70,6 +79,16 @@ EXP_HTML_REGEXP = [
     '<b>Mean count:</b> 12472<br/>',
     '<br/><hr/><br/>',
     '<img src = "data:image/png;base64,.*"/>']
+
+EXP_HTML_RAREFIED = [
+    '<b>Number of samples:</b> 3<br/>',
+    '<b>Number of features:</b> 3<br/>',
+    '<b>Minimum count:</b> 6<br/>',
+    '<b>Maximum count:</b> 6<br/>',
+    '<b>Median count:</b> 6<br/>',
+    '<b>Mean count:</b> 6<br/>',
+    '<br/><hr/><br/>',
+    'All the samples in your BIOM table have 6 sequences']
 
 
 if __name__ == '__main__':

--- a/qtp_biom/tests/test_summary.py
+++ b/qtp_biom/tests/test_summary.py
@@ -88,7 +88,8 @@ EXP_HTML_RAREFIED = [
     '<b>Median count:</b> 6<br/>',
     '<b>Mean count:</b> 6<br/>',
     '<br/><hr/><br/>',
-    'All the samples in your BIOM table have 6 sequences']
+    'All the samples in your BIOM table have 6 sequences, '
+    'no plot will be shown below.']
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This modifies the generation of the HTML summary to support rarefied tables. When a rarefied table was supplied, the generation of the plot failed with `LinAlgError: singular matrix`.

@adswafford, @ElDeveloper, @tanaes and I agreed that showing the plot for rarefied tables is not useful, and the proposed solution is to just show a message saying `All the samples in your BIOM table have %d sequences`, rather than showing the plot.

The github diff looks a bit messed up because I extracted the actual code that generates the HTML into a private function to facilitate testing. I have only added an if/else to check for the rarefied case and added a specific test.

This is the new summary:

<img width="381" alt="screen shot 2017-08-22 at 2 33 34 pm" src="https://user-images.githubusercontent.com/2501478/29588827-c894c2a0-8747-11e7-89b6-10c73e9b35ec.png">

If reviewed/merged quick can be deployed on the test system to be included in tomorrow's deploy.